### PR TITLE
Enable dotnet integration with systemd

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0",
+    "version": "6.0.1",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/TauStellwerk.Server/Program.cs
+++ b/src/TauStellwerk.Server/Program.cs
@@ -24,6 +24,7 @@ public static class Program
     public static void Main(string[] args)
     {
         CreateHostBuilder(args)
+            .UseSystemd() // This shouldn't do anything on non-systemd systems.
             .ConfigureLogging(config =>
             {
                 config.AddConsole(options => options.FormatterName = nameof(CustomLogFormatter))

--- a/src/TauStellwerk.Server/TauStellwerk.Server.csproj
+++ b/src/TauStellwerk.Server/TauStellwerk.Server.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="6.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This should impact non-systemd systems, but where systemd is used, type=notify can be used and the log levels of messages get propagated to journald (or whatever logging service one uses)