### PR TITLE
Re-enable trimming

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -1,10 +1,10 @@
 param($dotnet='dotnet')
 
-$customargs="-c Release --self-contained /p:DebugSymbols=false /p:DebugType=None  /p:EnableCompressionInSingleFile=true"
+$customargs="-c Release --self-contained /p:DebugSymbols=false /p:DebugType=None  /p:EnableCompressionInSingleFile=true /p:PublishTrimmed=true /p:TrimMode=CopyUsed /p:TreatWarningsAsErrors=false /nowarn:IL2026,IL2111,IL2104,IL2110,IL2091"
 $rids="linux-x64","linux-musl-x64","linux-arm64","linux-musl-arm64","win-x64","win-arm64"
 
 if (Test-Path ./publish){
-    Remove-Item ./publish -Recurse -Force
+    Remove-Item ./publish -Recurse -Force -ea ig
 }
 Invoke-Expression "$dotnet clean /p:PublishSingleFile=false -c Release"
 
@@ -12,8 +12,8 @@ foreach ($rid in $rids){
     
     # /bin and /obj folders need to be removed because the WebClient might not work otherwise
     # https://github.com/dotnet/aspnetcore/issues/38552
-    Remove-Item ./src/*/bin -force -recurse
-    Remove-Item ./src/*/obj -force -recurse
+    Remove-Item ./src/*/bin -force -recurse -ea ig
+    Remove-Item ./src/*/obj -force -recurse -ea ig
     
     Write-Host "--- Building $rid ---" -ForegroundColor Blue
     Invoke-Expression "$dotnet publish ./src/TauStellwerk.Server/ -r $rid -o ./publish/$rid $customargs"

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ set -e
 
 dotnet=${1:-dotnet}
 
-customargs="-c Release --self-contained /p:DebugSymbols=false /p:DebugType=None /p:EnableCompressionInSingleFile=true"
+customargs="-c Release --self-contained /p:DebugSymbols=false /p:DebugType=None  /p:EnableCompressionInSingleFile=true /p:PublishTrimmed=true /p:TrimMode=CopyUsed /p:TreatWarningsAsErrors=false /nowarn:IL2026,IL2111,IL2104,IL2110,IL2091"
 rids=("linux-x64" "linux-musl-x64" "linux-arm64" "linux-musl-arm64" "win-x64" "win-arm64")
 
 BLUE='\033[1;34m'


### PR DESCRIPTION
Resolves #180 

It still pops a lot of warnings that I just ignored. I did quite a bit of testing and was unable to locate any non-working functionality.
At some point it would probably make sense to use the integration tests (or something similar) to sanity-check the trimmed application, but it's good enough for me for now.


With compression and trimming the TauStellwerk.Server binaries get down to around 30MB (+ native dependencies and WebClient)