### PR TITLE
Caching NuGet dependencies

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,13 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-
+    - uses: actions/cache@v2
+      with:
+        path: ~/.nuget/packages
+        # Look to see if there is a cache hit for the corresponding requirements file
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget
     - name: Install dependencies
       run: dotnet restore
       


### PR DESCRIPTION
Mostly because the windows build can take a really long time to download the dependencies.
The build times on Ubuntu seem more or less unchanged, but not downloading the same package over and over again probably doesn't hurt.