### PR TITLE
Use results and .Bind in the SignalR Hub for engines

### DIFF
--- a/src/TauStellwerk.Server/Services/EngineService/EngineService.cs
+++ b/src/TauStellwerk.Server/Services/EngineService/EngineService.cs
@@ -130,7 +130,7 @@ public class EngineService : IEngineService
         return Result.Ok();
     }
 
-    public Result IsEngineAcquiredBySession(Session session, int engineId)
+    public Result CheckIsEngineAcquiredBySession(Session session, int engineId)
     {
         return _manager.GetActiveEngine(engineId, session).ToResult();
     }

--- a/src/TauStellwerk.Server/Services/EngineService/IEngineService.cs
+++ b/src/TauStellwerk.Server/Services/EngineService/IEngineService.cs
@@ -23,5 +23,5 @@ public interface IEngineService
 
     Task<Result> SetEngineFunction(Session session, int engineId, int functionNumber, State state);
 
-    Result IsEngineAcquiredBySession(Session session, int engineId);
+    Result CheckIsEngineAcquiredBySession(Session session, int engineId);
 }

--- a/test/TauStellwerk.Server.Test/Services/SessionServiceTests.cs
+++ b/test/TauStellwerk.Server.Test/Services/SessionServiceTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using FluentAssertions;
+using FluentResults.Extensions.FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -21,8 +22,9 @@ public class SessionServiceTests
 
         var session = sessionService.TryGetSession("Foo");
 
-        session.Should().NotBeNull();
-        session?.UserName.Should().Be("Alice");
+        session.Should().BeSuccess();
+        session.Value.UserName.Should().Be("Alice");
+        session.Value.ConnectionId.Should().Be("Foo");
     }
 
     [Test]
@@ -34,7 +36,7 @@ public class SessionServiceTests
 
         var session = sessionService.TryGetSession("Foo");
 
-        session.Should().BeNull();
+        session.Should().BeFailure();
     }
 
     [Test]


### PR DESCRIPTION
.Bind is a new feature from FluentResult - could work well for something like this, where it's just if (Result.IsFailed) after eachother