### PR TITLE
Update engines in list after editing one

### DIFF
--- a/src/TauStellwerk.Base/Dto/ResultDto{T}.cs
+++ b/src/TauStellwerk.Base/Dto/ResultDto{T}.cs
@@ -3,6 +3,7 @@
 // Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Diagnostics.CodeAnalysis;
 using FluentResults;
 
 namespace TauStellwerk.Base;
@@ -18,6 +19,7 @@ public class ResultDto<T>
 
     public string? Error { get; }
 
+    [MemberNotNullWhen(true, nameof(Value))]
     public bool Success { get; }
 
     public T? Value { get; }

--- a/src/TauStellwerk.Client/Model/Engine/EngineFull.cs
+++ b/src/TauStellwerk.Client/Model/Engine/EngineFull.cs
@@ -52,12 +52,7 @@ public partial class EngineFull : EngineOverview
 
     public static EngineFull? Create(EngineFullDto? engineDto)
     {
-        if (engineDto == null)
-        {
-            return null;
-        }
-
-        return new EngineFull(engineDto);
+        return engineDto is null ? null : new EngineFull(engineDto);
     }
 
     public EngineFullDto ToDto()

--- a/src/TauStellwerk.Desktop/Controls/DisposingWindow.cs
+++ b/src/TauStellwerk.Desktop/Controls/DisposingWindow.cs
@@ -1,0 +1,24 @@
+// <copyright file="DisposingWindow.cs" company="Dominic Ritz">
+// Copyright (c) Dominic Ritz. All rights reserved.
+// Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using Avalonia.Controls;
+
+namespace TauStellwerk.Desktop.Controls;
+
+/// <summary>
+/// A <see cref="Window"/> that disposed it's DataContext (if it's IDisposable) when closing.
+/// </summary>
+public class DisposingWindow : Window
+{
+    protected override void OnClosed(EventArgs e)
+    {
+        if (DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        base.OnClosed(e);
+    }
+}

--- a/src/TauStellwerk.Desktop/Views/Engine/EngineSelectionWindow.axaml.cs
+++ b/src/TauStellwerk.Desktop/Views/Engine/EngineSelectionWindow.axaml.cs
@@ -7,11 +7,12 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using JetBrains.Annotations;
+using TauStellwerk.Desktop.Controls;
 using TauStellwerk.Desktop.ViewModels;
 
 namespace TauStellwerk.Desktop.Views;
 
-public class EngineSelectionWindow : Window
+public class EngineSelectionWindow : DisposingWindow
 {
     public static readonly StyledProperty<int> ColumnsProperty = AvaloniaProperty.Register<EngineSelectionWindow, int>(nameof(Columns));
 

--- a/src/TauStellwerk.Desktop/Views/Turnouts/TurnoutsWindow.axaml.cs
+++ b/src/TauStellwerk.Desktop/Views/Turnouts/TurnoutsWindow.axaml.cs
@@ -7,11 +7,12 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using JetBrains.Annotations;
+using TauStellwerk.Desktop.Controls;
 using TauStellwerk.Desktop.ViewModels;
 
 namespace TauStellwerk.Desktop.Views;
 
-public class TurnoutsWindow : Window
+public class TurnoutsWindow : DisposingWindow
 {
     public TurnoutsWindow(TurnoutsViewModel vm)
     {
@@ -27,16 +28,6 @@ public class TurnoutsWindow : Window
     public TurnoutsWindow()
     {
         // https://github.com/AvaloniaUI/Avalonia/issues/2593
-    }
-
-    protected override void OnClosed(EventArgs e)
-    {
-        if (DataContext is TurnoutsViewModel vm)
-        {
-            vm.Dispose();
-        }
-
-        base.OnClosed(e);
     }
 
     private void InitializeComponent()

--- a/src/TauStellwerk.WebClient/Pages/SelectionContainer.razor
+++ b/src/TauStellwerk.WebClient/Pages/SelectionContainer.razor
@@ -3,10 +3,13 @@
 @using TauStellwerk.Client.Model
 @using TauStellwerk.Client.Services
 @using TauStellwerk.Util
+@using System.Collections.Immutable
 
 @inject ModalManager ModalManager
 @inject EngineService EngineService
 @inject AppState AppState
+
+@implements IDisposable
 
 <div id="EngineSelectionModal" class="modal @(ModalManager.IsEngineSelectionVisible ? "active-modal" : "inactive-modal")">
     <div class="modal-content-fullwidth">
@@ -23,7 +26,7 @@
             </select>
             <input id="ShowHiddenCheckbox" type="checkbox" @onchange="ShowHiddenCheckboxChanged" />
             <label>Show Hidden</label>
-            <span class="flex-filler" />
+            <span class="flex-filler"></span>
             <button class="bold button-secondary" @onclick="() => ModalManager.IsEngineSelectionVisible = false">X</button>
         </div>
         <div class="can-scroll-y modal-body">
@@ -48,6 +51,7 @@
     private static readonly int EnginesPerPage = 20;
     
     private readonly List<EngineOverview> _engines = new();
+    private readonly object _collectionLock = new();
 
     private bool CannotMoveForward => _engines.Count != EnginesPerPage;
     private bool CannotMoveBackward => _currentPage <= 0;
@@ -62,6 +66,28 @@
     {
         base.OnInitialized();
         ModalManager.PropertyChanged += HandleModalManagerNotification;
+        EngineService.EngineChanged += OnEngineChanged;
+    }
+
+    private void OnEngineChanged(object? sender, EngineFull e)
+    {
+        lock (_collectionLock)
+        {
+            for (var i = 0; i < _engines.Count; i++)
+            {
+                if (_engines[i].Id == e.Id)
+                {
+                    _engines[i] = e;
+                    StateHasChanged();
+                    return;
+                }
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        EngineService.EngineChanged -= OnEngineChanged;
     }
 
     private async void HandleModalManagerNotification(object? sender, PropertyChangedEventArgs args)
@@ -105,7 +131,6 @@
     private async Task ChangePage(int change)
     {
         _currentPage += change;
-        _engines.Clear();
 
         _currentPage = _currentPage.Clamp();
         _ = Enum.TryParse<SortEnginesBy>(_currentSorting, true, out var sortEnum);
@@ -115,8 +140,12 @@
             _isSortedDescending,
             _showHidden);
 
+        lock (_collectionLock)
+        {
+            _engines.Clear();
+            _engines.AddRange(engines);
+        }
         
-        _engines.AddRange(engines);
         StateHasChanged();
     }
 
@@ -126,4 +155,5 @@
         AppState.SelectedEngine = engine;
         ModalManager.IsEngineEditModalVisible = true;
     }
+
 }


### PR DESCRIPTION
Resolves #233, includes WebClient and Desktop

EngineService raises a EngineChanged Event after updating - the viewmodels can subscribe to that and update engines based on their Id. Only done locally, that's where it's noticeable.