### PR TITLE
Improvements for the createTestDb-Tool

### DIFF
--- a/src/TauStellwerk.Tools/CreateTestDb/CreateTestDbTool.cs
+++ b/src/TauStellwerk.Tools/CreateTestDb/CreateTestDbTool.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Microsoft.EntityFrameworkCore;
+using TauStellwerk.Base;
 using TauStellwerk.Server.Database;
 using TauStellwerk.Server.Database.Model;
 
@@ -19,15 +20,37 @@ public static class CreateTestDbTool
         await context.Database.MigrateAsync();
 
         var engineList = EngineDtoGenerator.GetEngineFullDtos(options.Count);
+        var tags = await CollectTags(engineList, context);
 
-        foreach (var engineDto in engineList)
+        foreach (var engineDtoChunk in engineList.Chunk(100))
         {
-            var engine = new Engine();
-            await engine.UpdateWith(engineDto, context);
-            context.Add(engine);
-            await context.SaveChangesAsync();
+            foreach (var engineDto in engineDtoChunk)
+            {
+                var engine = new Engine()
+                {
+                    Tags = engineDto.Tags.Select(s => tags[s]).ToList(),
+                };
 
-            Console.WriteLine($"Created engine {engine.Name}");
+                await engine.UpdateWith(engineDto, context);
+
+                context.Add(engine);
+                Console.WriteLine($"Created engine {engine.Name}");
+            }
+
+            await context.SaveChangesAsync();
         }
+    }
+
+    public static async Task<Dictionary<string, Tag>> CollectTags(IList<EngineFullDto> engines, StwDbContext dbContext)
+    {
+        var tags = engines.SelectMany(e => e.Tags).Distinct().ToList();
+        var existingTags = await dbContext.Tags.ToListAsync();
+        var tagsToInsert = tags.Except(existingTags.Select(t => t.Name)).Select(s => new Tag(0, s)).ToList();
+
+        await dbContext.Tags.AddRangeAsync(tagsToInsert);
+        await dbContext.SaveChangesAsync();
+
+        existingTags.AddRange(tagsToInsert);
+        return existingTags.ToDictionary(t => t.Name);
     }
 }

--- a/src/TauStellwerk.Tools/CreateTestDb/EngineDtoGenerator.cs
+++ b/src/TauStellwerk.Tools/CreateTestDb/EngineDtoGenerator.cs
@@ -6,44 +6,63 @@
 using TauStellwerk.Base;
 using TauStellwerk.Util;
 
+// ReSharper disable ArrangeObjectCreationWhenTypeNotEvident
 namespace TauStellwerk.Tools.CreateTestDb;
 
 public static class EngineDtoGenerator
 {
     private static readonly List<EngineNameSet> _engineNameComponents = new()
     {
-        new("BLS Re 465 {0:000} (Blue)", 1, 18, 160, new() { "Universal", "SLM" }),
-        new("BLS Re 465 {0:000} (Green)", 1, 18, 160, new() { "Universal", "SLM" }),
-        new("BLS Re 475 {0:000} (Alpinist)", 1, 15, 200, new() { "Freight", "Siemens" }),
-        new("BLS Re 485 {0:000} (Connecting Europe)", 1, 20, 140, new() { "Freight", "Bombardier" }),
-        new("BLS Re 485 {0:000} (Alpinist)", 1, 20, 140, new() { "Freight", "Bombardier" }),
-        new("BLS Re 486 {0:000} (Alpinist)", 1, 10, 140, new() { "Freight", "Bombardier" }),
+        new("BLS Re 465 {0:000} (Blue)", 1, 18, 160, new() { "Universal", "Long-Distance", "Regional", "SLM", "CH" }),
+        new("BLS Re 465 {0:000} (Green)", 1, 18, 160, new() { "Universal", "Long-Distance", "Regional", "SLM", "CH" }),
+        new("BLS Re 475 {0:000} (Alpinist)", 401, 415, 200, new() { "Freight", "Siemens", "D/A/CH/I/NL", "Vectron MS" }),
+        new("BLS Re 475 {0:000} (Alpinist)", 416, 440, 200, new() { "Freight", "Siemens", "D/A/CH/I/NL/B", "Vectron MS" }),
+        new("BLS Re 485 {0:000} (Connecting Europe)", 1, 20, 140, new() { "Freight", "Bombardier", "D/CH", "Traxx F140 AC1" }),
+        new("BLS Re 485 {0:000} (Alpinist)", 1, 20, 140, new() { "Freight", "Bombardier", "D/CH", "Traxx F140 AC1" }),
+        new("BLS Re 486 {0:000} (Alpinist)", 1, 10, 140, new() { "Freight", "Bombardier", "D/A/CH/I", "Traxx F140 MS2E" }),
 
-        new("Hupac BR 193 {0:000}", 490, 497, 200, new() { "Freight", "Siemens", "DACHINL", "Vectron MS" }),
+        new("DB BR 185 {0:000}", 85, 94, 140, new() { "Freight", "Bombardier", "Traxx F140 AC1", "D/A/CH" }),
+        new("DB BR 185 {0:000}", 95, 149, 140, new() { "Freight", "Bombardier", "Traxx F140 AC1", "D/CH" }),
 
-        new("Railcare Rem 476 {0:000}", 451, 457, 200, new() { "Freight", "Siemens" }),
+        new("Hupac BR 193 {0:000}", 490, 497, 200, new() { "Freight", "Siemens", "D/A/CH/I/NL", "Vectron MS" }),
 
-        new("SBB Re 4/4 {0} (Green)", 11101, 11376, 140, new() { "Universal", "SLM" }),
-        new("SBB Re 420 {0:000} (Red)", 101, 349, 140, new() { "Universal", "SLM" }),
-        new("SBB Re 420 {0:000} (LION)", 201, 230, 140, new() { "Universal", "SLM" }),
-        new("SBB Re 620 {0:000}", 0, 89, 140, new() { "Universal", "SLM" }),
-        new("SBB Re 460 {0:000} (Lok 2000)", 0, 118, 200, new() { "Passenger", "SLM" }),
-        new("SBB Re 460 {0:000} (Refit)", 0, 118, 200, new() { "Passenger", "SLM" }),
+        new("Railcare Rem 476 {0:000}", 451, 457, 200, new() { "Freight", "Siemens", "Vectron AC" }),
+
+        new("SBB Ae 6/6 {0} (Green)", 11401, 11520, 125, new() { "SLM", "BBC", "MFO", "Universal", "Long-Distance", "Regional", "CH" }),
+        new("SBB Ae 6/6 {0} (Red)", 11401, 11520, 125, new() { "SLM", "BBC", "MFO", "Universal", "Long-Distance", "Regional", "CH" }),
+        new("SBB Ae 610 {0:000} (Red)", 401, 520, 125, new() { "Universal", "Long-Distance", "Regional", "SLM", "CH" }),
+        new("SBB RABDe 500 {0:000}", 0, 43, 200, new() { "Passenger", "Long-Distance", "ICN", "Adtranz", "Tilting Train", "CH" }),
+        new("SBB RABe 501 {0:000}", 1, 29, 250, new() { "Giruno", "Long-Distance", "Passenger", "Stadler", "D/A/CH/I" }),
+        new("SBB RBDe 560 {0:000}", 0, 141, 140, new() { "Passenger", "Regional", "FFA", "BBC", "Schindler Waggon", "ABB", "SIG", "CH" }),
+        new("SBB RBDe 560 {0:000} (Domino)", 203, 307, 140, new() { "Passenger", "Regional", "FFA", "BBC", "Schindler Waggon", "ABB", "SIG", "CH" }),
+        new("SBB RBDe 560 {0:000} (RegioAlps)", 401, 416, 140, new() { "Passenger", "Regional", "FFA", "BBC", "Schindler Waggon", "ABB", "SIG", "CH" }),
+        new("SBB RBDe 560 {0:000} (Glarner Sprinter)", 201, 202, 140, new() { "Passenger", "Regional", "FFA", "BBC", "Schindler Waggon", "ABB", "SIG", "CH" }),
+        new("SBB Re 4/4 {0} (Green)", 11101, 11376, 140, new() { "Universal", "Long-Distance", "Regional", "SLM", "BBC", "MFO", "SAAS", "CH" }),
+        new("SBB Re 420 {0:000} (Red)", 101, 349, 140, new() { "Universal", "Long-Distance", "Regional", "SLM", "BBC", "MFO", "SAAS", "CH" }),
+        new("SBB Re 420 {0:000} (LION)", 201, 230, 140, new() { "Passenger", "Regional", "SLM", "BBC", "MFO", "SAAS", "CH" }),
+        new("SBB Re 6/6 {0} (Green)", 11601, 11689, 140, new() { "Universal", "Long-Distance", "SLM", "BBC", "SAAS", "CH" }),
+        new("SBB Re 620 {0:000} (Red)", 0, 89, 140, new() { "Universal", "Long-Distance", "SLM", "BBC", "SAAS", "CH" }),
+        new("SBB Re 450 {0:000} (DPZ)", 0, 114, 140, new() { "Passenger", "Regional", "SLM", "Schindler Waggon", "ABB", "SIG", "ZVV", "CH" }),
+        new("SBB Re 450 {0:000} (DPZ+)", 0, 114, 140, new() { "Passenger", "Regional", "SLM", "Schindler Waggon", "ABB", "SIG", "ZVV", "CH" }),
+        new("SBB Re 460 {0:000} (Lok 2000)", 0, 118, 200, new() { "Passenger", "Long-Distance", "SLM", "ABB", "CH" }),
+        new("SBB Re 460 {0:000} (Refit)", 0, 118, 200, new() { "Passenger", "Long-Distance", "SLM", "ABB", "CH" }),
         new("SBB Re 474 {0:000} (SBB Cargo)", 1, 18, 140, new() { "Freight", "Siemens" }),
         new("SBB Re 482 {0:000} (SBB Cargo)", 0, 49, 140, new() { "Freight", "Bombardier" }),
         new("SBB Re 484 {0:000} (SBB Cargo)", 2, 21, 140, new() { "Freight", "Bombardier" }),
         new("SBB Re 484 {0:000} (SBB Cargo)", 103, 105, 140, new() { "Freight", "Bombardier" }),
-        new("SBB Ae 610 {0:000} (Red)", 401, 520, 125, new() { "Universal", "SLM" }),
         new("SBB BR 193 {0:000} (Daypiercer)", 461, 478, 20, new() { "Freight", "Siemens", "LokRoll" }),
 
-        new("SOB Re 446 {0:000}", 15, 18, 160, new() { "Universal", "SLM" }),
-        new("SOB Re 456 {0:000}", 91, 96, 130, new() { "Universal", "SLM" }),
+        new("SOB RABe 526 {0:000} (FLIRT)", 41, 63, 160, new() { "Passenger", "Long-Distance", "Regional", "Stadler", "CH" }),
+        new("SOB RABe 526 {0:000} (FLIRT 3)", 1, 10, 160, new() { "Passenger", "Long-Distance", "Regional", "Stadler", "CH" }),
+        new("SOB RABe 526 {0:000} (Traverso)", 101, 124, 160, new() { "Passenger", "Long-Distance", "Stadler", "CH" }),
+        new("SOB Re 446 {0:000}", 15, 18, 160, new() { "Universal", "Long-Distance", "SLM", "CH" }),
+        new("SOB Re 456 {0:000}", 91, 96, 130, new() { "Universal", "Long-Distance", "SLM", "CH" }),
 
-        new("SRT Rem 487 {0:000} (Biene Maja)", 1, 1, 140, new() { "Freight", "Bombardier" }),
+        new("SRT Rem 487 {0:000} (Biene Maja)", 1, 1, 140, new() { "Freight", "Bombardier", "D/A/CH", "Traxx AC3 (LM)" }),
     };
 
     private static readonly List<string> _manufacturerTags = new() { "Märklin", "Piko", "Roco", "LS Models", "HAG", "Lilliput", "ESU" };
-    private static readonly List<string> _ownerTag = new() { "Peter", "Mike", "Sara", "Max", "Jean" };
+    private static readonly List<string> _ownerTag = new() { "Peter", "Mike", "Sara", "Max", "Jean", "Ralf", "Simon", "Hans", "Ueli" };
 
     public static EngineFullDto GetEngineDto()
     {
@@ -97,6 +116,7 @@ public static class EngineDtoGenerator
         tags.AddRange(engineNameSet.Tags);
         tags.Add(_manufacturerTags.TakeRandom(random));
         tags.Add(_ownerTag.TakeRandom(random));
+        tags.AddRange(new List<string> { "DCC", "Sound" });
 
         return new EngineFullDto()
         {
@@ -110,6 +130,19 @@ public static class EngineDtoGenerator
             {
                 new(0, "Headlights", 0),
                 new(1, "Sound", 0),
+                new(2, "Horn (short/high)", 500),
+                new(3, "Horn (short/low)", 500),
+                new(4, "Horn (long/high)", 0),
+                new(5, "Horn (long/low)", 0),
+                new(6, "High Beams", 0),
+                new(7, "1x Red", 0),
+                new(8, "2x Red", 0),
+                new(9, "Compressor", 0),
+                new(10, "Fans", 0),
+                new(11, "Conductor's Whistle", 1000),
+                new(12, "Shunting mode", 0),
+                new(13, "Station announcement: passing train", 3500),
+
             },
         };
     }
@@ -123,6 +156,7 @@ public static class EngineDtoGenerator
             MaxNumber = maxNumber;
             TopSpeed = topSpeed;
             Tags = tags;
+            TotalNumber = MaxNumber - MinNumber + 1;
         }
 
         public string ClassName { get; }
@@ -131,7 +165,7 @@ public static class EngineDtoGenerator
 
         public int MaxNumber { get; }
 
-        public int TotalNumber => MaxNumber - MinNumber + 1;
+        public int TotalNumber { get; }
 
         public int TopSpeed { get; }
 

--- a/src/TauStellwerk.Tools/CreateTestDb/EngineDtoGenerator.cs
+++ b/src/TauStellwerk.Tools/CreateTestDb/EngineDtoGenerator.cs
@@ -118,6 +118,11 @@ public static class EngineDtoGenerator
         tags.Add(_ownerTag.TakeRandom(random));
         tags.AddRange(new List<string> { "DCC", "Sound" });
 
+        // Add two random numbers as a tag to simulate the usage as "alternative names"
+        // For example one could add the full UIC-Numbers to an engine => many "single-use" tags
+        tags.Add(random.NextInt64(0, 999_999_999).ToString());
+        tags.Add(random.NextInt64(0, 999_999_999).ToString());
+
         return new EngineFullDto()
         {
             Name = string.Format(engineNameSet.ClassName, number),
@@ -142,7 +147,6 @@ public static class EngineDtoGenerator
                 new(11, "Conductor's Whistle", 1000),
                 new(12, "Shunting mode", 0),
                 new(13, "Station announcement: passing train", 3500),
-
             },
         };
     }


### PR DESCRIPTION
Generally tested with 10K engines

- Chunking the engines and SaveChanging them at once really helps with performance.
- More engines added to the random generator part
- More tags and more functions to get closes to a "real" database.
   (Performance has lowered from ~12ms to ~39ms (3900X and NVMe system) for the first few pages. Should make for a much better benchmark, even if 10K engines are probably on the upper end. 