### PR TITLE
Pin .NET SDK 7.0.103 to fix failing builds

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  DOTNET_VERSION: '7.0.x' # The .NET SDK version to use
+  DOTNET_VERSION: '7.0.103' # The .NET SDK version to use
 jobs:
   build-and-test:
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.0",
-    "rollForward": "latestFeature",
+    "version": "7.0.103",
+    "rollForward": "Disable",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Seems to be a bug in .NET, "@bind:after" was upgraded from having an annoying bug to a really annoying one.