### PR TITLE
Replace moq with NSubstitute

### DIFF
--- a/src/TauStellwerk.CommandStations/TauStellwerk.CommandStations.csproj
+++ b/src/TauStellwerk.CommandStations/TauStellwerk.CommandStations.csproj
@@ -7,6 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentResults" Version="3.15.2" />
 		<PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/TauStellwerk.Client.Tests/TauStellwerk.Client.Tests.csproj
+++ b/test/TauStellwerk.Client.Tests/TauStellwerk.Client.Tests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1">

--- a/test/TauStellwerk.CommandStations.Tests/ECoS/ConnectionHandlerTests.cs
+++ b/test/TauStellwerk.CommandStations.Tests/ECoS/ConnectionHandlerTests.cs
@@ -9,7 +9,7 @@ using System.Text;
 using FluentAssertions;
 using FluentResults.Extensions.FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using TauStellwerk.CommandStations;
 using TauStellwerk.CommandStations.ECoS;
@@ -29,7 +29,7 @@ public class ConnectionHandlerTests
     [SetUp]
     public async Task SetUp()
     {
-        var logger = new Mock<ILogger<CommandStationBase>>().Object;
+        var logger = Substitute.For<ILogger<CommandStationBase>>();
         _tcpListener = new TestTcpListener();
         var listenerTask = _tcpListener.Start();
         _connectionHandler = new ECosConnectionHandler(_ip, Port, logger);

--- a/test/TauStellwerk.CommandStations.Tests/TauStellwerk.CommandStations.Tests.csproj
+++ b/test/TauStellwerk.CommandStations.Tests/TauStellwerk.CommandStations.Tests.csproj
@@ -9,7 +9,6 @@
 		<PackageReference Include="FluentAssertions" Version="6.11.0" />
 		<PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.6.1">

--- a/test/TauStellwerk.Server.IntegrationTests/IntegrationTestBase.cs
+++ b/test/TauStellwerk.Server.IntegrationTests/IntegrationTestBase.cs
@@ -6,7 +6,7 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using TauStellwerk.Base;
 using TauStellwerk.Client.Model;
@@ -26,10 +26,8 @@ public class IntegrationTestBase
 
     protected IConnectionService CreateConnectionService()
     {
-        var settingService = new Mock<ISettingsService>(MockBehavior.Strict);
-
-        settingService.Setup(s => s.GetSettings().Result)
-            .Returns(() => new ImmutableSettings("TEST", _factory.Server.BaseAddress.ToString(), string.Empty, false, "en"));
+        var settingService = Substitute.For<ISettingsService>();
+        settingService.GetSettings().Returns(new ImmutableSettings("TEST", _factory.Server.BaseAddress.ToString(), string.Empty, false, "en"));
 
         var hubConnection = new HubConnectionBuilder().WithUrl(
             _factory.Server.BaseAddress + "hub",
@@ -37,6 +35,6 @@ public class IntegrationTestBase
             .AddJsonProtocol(options => options.PayloadSerializerOptions.AddContext<TauJsonContext>())
             .Build();
 
-        return new ConnectionService(settingService.Object, hubConnection);
+        return new ConnectionService(settingService, hubConnection);
     }
 }

--- a/test/TauStellwerk.Server.IntegrationTests/TauStellwerk.Server.IntegrationTests.csproj
+++ b/test/TauStellwerk.Server.IntegrationTests/TauStellwerk.Server.IntegrationTests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/test/TauStellwerk.Server.Test/Database/EngineDaoTests.cs
+++ b/test/TauStellwerk.Server.Test/Database/EngineDaoTests.cs
@@ -6,7 +6,7 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using TauStellwerk.Base;
 using TauStellwerk.Data.Dao;
@@ -36,8 +36,8 @@ public class EngineDaoTests : ContextTestBase
 
         await using (var context = GetContext())
         {
-            var logger = new Mock<ILogger<EngineDao>>();
-            var engineDao = new EngineDao(context, logger.Object);
+            var logger = Substitute.For<ILogger<EngineDao>>();
+            var engineDao = new EngineDao(context, logger);
 
             _ = engineDao.GetEngine(engine.Id);
         }
@@ -166,7 +166,7 @@ public class EngineDaoTests : ContextTestBase
 
     private EngineDao GetDao()
     {
-        var loggerMock = new Mock<ILogger<EngineDao>>();
-        return new EngineDao(GetContext(), loggerMock.Object);
+        var loggerMock = Substitute.For<ILogger<EngineDao>>();
+        return new EngineDao(GetContext(), loggerMock);
     }
 }

--- a/test/TauStellwerk.Server.Test/TauStellwerk.Server.Test.csproj
+++ b/test/TauStellwerk.Server.Test/TauStellwerk.Server.Test.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />


### PR DESCRIPTION
See https://github.com/moq/moq/issues/1372

Wasn't super critical for me personally, but I'd rather comply with the GDPR.
While the offending Code has been removed due to issues on Mac and Linux, it's unclear what will happen in the future.
In any case. the trust in moq is seriously damaged.
To mitigate further risk, I want to remove moq and use NSubstitute instead.