### PR TITLE
Introduce cache busting for WebClient and Desktop

### DIFF
--- a/src/TauStellwerk.Base/Dto/EngineOverviewDto.cs
+++ b/src/TauStellwerk.Base/Dto/EngineOverviewDto.cs
@@ -15,6 +15,9 @@ public class EngineOverviewDto
 
     public List<ImageDto> Images { get; set; } = new();
 
+    // Intentionally not a long, wanna keep the number short, collisions should be unlikely anyway
+    public int ImageTimestamp { get; set; }
+
     public DateTime LastUsed { get; set; }
 
     public DateTime Created { get; set; }

--- a/src/TauStellwerk.Client/Model/Engine/EngineOverview.cs
+++ b/src/TauStellwerk.Client/Model/Engine/EngineOverview.cs
@@ -25,6 +25,7 @@ public partial class EngineOverview : ObservableObject
         Id = dto.Id;
         Tags = new ObservableCollection<string>(dto.Tags);
         Images = EngineImage.CreateFromImageDtoList(dto.Images);
+        ImageTimestamp = dto.ImageTimestamp;
         LastUsed = dto.LastUsed;
         Created = dto.Created;
     }
@@ -43,6 +44,8 @@ public partial class EngineOverview : ObservableObject
     public ObservableCollection<string> Tags { get; init; }
 
     public ImmutableList<EngineImage> Images { get; init; }
+
+    public int ImageTimestamp { get; init; }
 
     public DateTime LastUsed { get; init; }
 

--- a/src/TauStellwerk.Data/Model/Engine.cs
+++ b/src/TauStellwerk.Data/Model/Engine.cs
@@ -86,6 +86,7 @@ public class Engine
             LastUsed = LastUsed,
             Created = Created,
             IsHidden = IsHidden,
+            ImageTimestamp = (int)(LastImageUpdate?.Ticks ?? 0),
         };
     }
 
@@ -103,6 +104,7 @@ public class Engine
             Address = Address,
             Functions = Functions.Select(f => f.ToFunctionDto()).ToList(),
             IsHidden = IsHidden,
+            ImageTimestamp = (int)(LastImageUpdate?.Ticks ?? 0),
         };
     }
 

--- a/src/TauStellwerk.Desktop/Views/Engine/EngineControlWindow.axaml
+++ b/src/TauStellwerk.Desktop/Views/Engine/EngineControlWindow.axaml
@@ -21,6 +21,7 @@
                Grid.ColumnSpan="2" Padding="4"/>
         <controls:EngineImageControl Grid.Column="1" Grid.Row="1"
                EngineImages="{Binding Engine.Images}"
+               ImageTimestamp="{Binding Engine.ImageTimestamp}"
                Stretch="Uniform"
                StretchDirection="Both"
                Margin="2"/>

--- a/src/TauStellwerk.Desktop/Views/Engine/EngineSelectionWindow.axaml
+++ b/src/TauStellwerk.Desktop/Views/Engine/EngineSelectionWindow.axaml
@@ -59,7 +59,7 @@
 						<DataTemplate>
 							<Grid MinWidth="200" Tag="{Binding Id}" VerticalAlignment="Stretch" ColumnDefinitions="*" RowDefinitions="Auto, Auto, *, Auto" Margin="4">
 								<TextBlock Text="{Binding Name}"  Padding="4" Grid.Row="0"/>
-								<controls:EngineImageControl EngineImages="{Binding Images}" Grid.Row="1"/>
+								<controls:EngineImageControl EngineImages="{Binding Images}" ImageTimestamp="{Binding ImageTimestamp}" Grid.Row="1"/>
 								<ItemsControl ItemsSource="{Binding Tags}" VerticalAlignment="Stretch" Grid.Row="2">
 									<ItemsControl.ItemsPanel>
 										<ItemsPanelTemplate>

--- a/src/TauStellwerk.WebClient/Pages/EngineController.razor
+++ b/src/TauStellwerk.WebClient/Pages/EngineController.razor
@@ -15,7 +15,7 @@
         <span class="flex-filler"></span>
         <button class="bold button-secondary" @onclick="RemoveEngine">X</button>
     </div>
-    <EnginePicture Class="ec-grid-image" Images="Engine.Images" Sizes="Sizes" />
+    <EnginePicture Class="ec-grid-image" Images="Engine.Images" Sizes="Sizes" ImageTimestamp="Engine.ImageTimestamp" />
     <label class="ec-grid-slider has-100percent-height">
         <!-- orient="vertical" is for firefox -->
         <input type="range" orient="vertical" min="0" max="126" value="@Engine.Throttle" @oninput="SetSpeed" />

--- a/src/TauStellwerk.WebClient/Pages/EnginePicture.razor
+++ b/src/TauStellwerk.WebClient/Pages/EnginePicture.razor
@@ -1,11 +1,13 @@
 @using System.Collections.Immutable
+@using System.ComponentModel
 @using TauStellwerk.Client.Model
+@using System.Buffers.Text
 <picture class="@Class">
     @if (!_hasErrorOccurredYet)
     {
         @foreach (var imageset in Images.GroupBy(e => e.Importance).OrderBy(x => x.Key))
         {
-            var srcset = string.Join(',', imageset.Select(i => $"images/{i.Filename} {i.Width}w"));
+            var srcset = string.Join(',', imageset.Select(i => $"images/{i.Filename}?v={ImageTimestamp:X} {i.Width}w"));
             <source sizes="@Sizes" srcset="@srcset" type="@imageset.FirstOrDefault()?.Type">
         }
     }
@@ -23,6 +25,10 @@
     [Parameter]
     [EditorRequired]
     public string Sizes { get; set; } = string.Empty;
+    
+    [Parameter]
+    [EditorRequired]
+    public int ImageTimestamp { get; set; }
 
     [Parameter]
     public string Class { get; set; } = string.Empty;

--- a/src/TauStellwerk.WebClient/Pages/SelectionEngine.razor
+++ b/src/TauStellwerk.WebClient/Pages/SelectionEngine.razor
@@ -8,7 +8,7 @@
 
 <article class="has-shadow is-flex-vertical">
     <header>@Engine.Name</header>
-    <EnginePicture Class="selection-image" Images="Engine.Images" Sizes="Sizes"/>
+    <EnginePicture Class="selection-image" Images="Engine.Images" Sizes="Sizes" ImageTimestamp="Engine.ImageTimestamp"/>
     <span class="tags">
         @foreach (var tag in Engine.Tags)
         {


### PR DESCRIPTION
Desktop now finally uses cached images
Both use the lowest 32bit of the DateTime.Tick when the image was last updated.
I'd assume colision are rather unlikely.
As the 32bits are used as part of the filename on the desktop app, I'd like to keep them short, which is why I opted for 32 bits. 