### PR TITLE
Desktop: Improvements to the new main menu, some other maintenance

### DIFF
--- a/src/TauStellwerk.Client/Resources/Resources.Designer.cs
+++ b/src/TauStellwerk.Client/Resources/Resources.Designer.cs
@@ -213,6 +213,15 @@ namespace TauStellwerk.Client.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Options.
+        /// </summary>
+        public static string Options {
+            get {
+                return ResourceManager.GetString("Options", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove Function.
         /// </summary>
         public static string RemoveFunction {
@@ -362,6 +371,15 @@ namespace TauStellwerk.Client.Resources {
         public static string Tags {
             get {
                 return ResourceManager.GetString("Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle large stop button.
+        /// </summary>
+        public static string ToggleLargeStopButton {
+            get {
+                return ResourceManager.GetString("ToggleLargeStopButton", resourceCulture);
             }
         }
         

--- a/src/TauStellwerk.Client/Resources/Resources.de.resx
+++ b/src/TauStellwerk.Client/Resources/Resources.de.resx
@@ -231,4 +231,10 @@
   <data name="Open" xml:space="preserve">
     <value>Öffnen</value>
   </data>
+  <data name="Options" xml:space="preserve">
+    <value>Optionen</value>
+  </data>
+  <data name="ToggleLargeStopButton" xml:space="preserve">
+    <value>Grosse Stoptaste aktivieren/deaktivieren</value>
+  </data>
 </root>

--- a/src/TauStellwerk.Client/Resources/Resources.gsw.resx
+++ b/src/TauStellwerk.Client/Resources/Resources.gsw.resx
@@ -132,4 +132,10 @@
     <data name="Open" xml:space="preserve">
         <value>Öffne</value>
     </data>
+  <data name="Options" xml:space="preserve">
+    <value>Optione</value>
+  </data>
+  <data name="ToggleLargeStopButton" xml:space="preserve">
+    <value>Grosse Stopchnopf aktiviere/deaktiviere</value>
+  </data>
 </root>

--- a/src/TauStellwerk.Client/Resources/Resources.resx
+++ b/src/TauStellwerk.Client/Resources/Resources.resx
@@ -231,4 +231,10 @@
   <data name="Open" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="Options" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="ToggleLargeStopButton" xml:space="preserve">
+    <value>Toggle large stop button</value>
+  </data>
 </root>

--- a/src/TauStellwerk.Client/Services/StatusService.cs
+++ b/src/TauStellwerk.Client/Services/StatusService.cs
@@ -51,7 +51,6 @@ public class StatusService
 
     private void HandleStatusChange(SystemStatus? newSystemStatus)
     {
-        Console.WriteLine($"Recivied status change notification");
         LastKnownStatus = newSystemStatus;
         StatusChanged?.Invoke(this, newSystemStatus);
     }

--- a/src/TauStellwerk.Desktop/Controls/StopButtonControl.axaml
+++ b/src/TauStellwerk.Desktop/Controls/StopButtonControl.axaml
@@ -7,7 +7,7 @@
              x:Class="TauStellwerk.Desktop.Controls.StopButtonControl"
              x:DataType="viewModels:StopButtonControlViewModel"
              x:CompileBindings="True">
-  <Button IsEnabled="{Binding ShouldBeEnabled}" Name="StopButton" Margin="50 0 50 0" HorizontalAlignment="Stretch" Command="{Binding StopButtonCommand}">
+  <Button IsEnabled="{Binding ShouldBeEnabled}" Name="StopButton" HorizontalAlignment="Stretch" Command="{Binding StopButtonCommand}">
             <StackPanel HorizontalAlignment="Center">
               <Label Content="{Binding CurrentState}" FontSize="24"/>
               <TextBlock>

--- a/src/TauStellwerk.Desktop/Controls/StopButtonControl.axaml.cs
+++ b/src/TauStellwerk.Desktop/Controls/StopButtonControl.axaml.cs
@@ -2,6 +2,7 @@
 //  Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
 
 using Avalonia.Controls;
+using Splat;
 using TauStellwerk.Desktop.ViewModels;
 
 namespace TauStellwerk.Desktop.Controls;
@@ -12,6 +13,6 @@ public partial class StopButtonControl : UserControl
     {
         InitializeComponent();
 
-        DataContext = new StopButtonControlViewModel();
+        DataContext = Locator.Current.GetRequiredService<StopButtonControlViewModel>();
     }
 }

--- a/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml
+++ b/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml
@@ -4,25 +4,35 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:TauStellwerk.Desktop.ViewModels"
              xmlns:r="clr-namespace:TauStellwerk.Client.Resources;assembly=TauStellwerk.Client"
+             xmlns:controls="clr-namespace:TauStellwerk.Desktop.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="TauStellwerk.Desktop.Controls.TopMenuControl"
              x:DataType="viewModels:TopMenuViewModel"
              x:CompileBindings="True">
-    <Menu Margin="0 0 0 5">
-        <MenuItem Header="{x:Static r:Resources.Open}">
-            <MenuItem Header="{x:Static r:Resources.EngineList}" Command="{Binding OpenEngineListCommand}" />
-            <MenuItem Header="{x:Static r:Resources.TurnoutList}" Command="{Binding OpenTurnoutListCommand}" />
-        </MenuItem>
-        <MenuItem Header="{x:Static r:Resources.Settings}" Command="{Binding OpenSettingsCommand}" />
-        <MenuItem 
-            Command="{Binding StopButtonVm.StopButtonCommand}" 
-            Header="{Binding StopButtonVm.CurrentState}">
-            <ToolTip.Tip>
-                <TextBlock>
-                    <Run Text="{Binding StopButtonVm.LastAction}"/>
-                    <Run Text="{Binding StopButtonVm.LastActionUsername}" FontWeight="Bold" />
-                </TextBlock>
-            </ToolTip.Tip>
-        </MenuItem>
-    </Menu>
+    <StackPanel Margin="0 0 0 5">
+        <Menu>
+            <MenuItem Header="{x:Static r:Resources.Open}">
+                <MenuItem Header="{x:Static r:Resources.EngineList}" Command="{Binding OpenEngineListCommand}" />
+                <MenuItem Header="{x:Static r:Resources.TurnoutList}" Command="{Binding OpenTurnoutListCommand}" />
+            </MenuItem>
+            <MenuItem Header="{x:Static r:Resources.Options}">
+                <MenuItem Header="{x:Static r:Resources.Settings}" Command="{Binding OpenSettingsCommand}" />
+                <MenuItem Header="{x:Static r:Resources.ToggleLargeStopButton}" Command="{Binding ToggleLargeButtonCommand}"/>
+            </MenuItem>
+            <MenuItem
+                IsVisible="{Binding !UseLargeButton}"
+                Command="{Binding StopButtonVm.StopButtonCommand}"
+                Header="{Binding StopButtonVm.CurrentState}">
+                <ToolTip.Tip>
+                    <TextBlock>
+                        <Run Text="{Binding StopButtonVm.LastAction}"/>
+                        <Run Text="{Binding StopButtonVm.LastActionUsername}" FontWeight="Bold" />
+                    </TextBlock>
+                </ToolTip.Tip>
+            </MenuItem>
+        </Menu>
+        <Panel IsVisible="{Binding UseLargeButton}" Margin="0 2 0 0">
+            <controls:StopButtonControl/>
+        </Panel>
+    </StackPanel>
 </UserControl>

--- a/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml
+++ b/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml
@@ -8,7 +8,7 @@
              x:Class="TauStellwerk.Desktop.Controls.TopMenuControl"
              x:DataType="viewModels:TopMenuViewModel"
              x:CompileBindings="True">
-    <Menu>
+    <Menu Margin="0 0 0 5">
         <MenuItem Header="{x:Static r:Resources.Open}">
             <MenuItem Header="{x:Static r:Resources.EngineList}" Command="{Binding OpenEngineListCommand}" />
             <MenuItem Header="{x:Static r:Resources.TurnoutList}" Command="{Binding OpenTurnoutListCommand}" />

--- a/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml.cs
+++ b/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of the TauStellwerk project.
 //  Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
 
+using Avalonia;
 using Avalonia.Controls;
 using TauStellwerk.Desktop.ViewModels;
 
@@ -8,10 +9,24 @@ namespace TauStellwerk.Desktop.Controls;
 
 public partial class TopMenuControl : UserControl
 {
+
+    private readonly TopMenuViewModel _vm;
+
     public TopMenuControl()
     {
         InitializeComponent();
+        _vm = new TopMenuViewModel();
+        DataContext = _vm;
+    }
 
-        DataContext = new TopMenuViewModel();
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        _vm.UpdateWindowType(TryGetContainingWindowType());
+        base.OnAttachedToVisualTree(e);
+    }
+
+    private string TryGetContainingWindowType()
+    {
+        return VisualRoot?.GetType().ToString() ?? string.Empty;
     }
 }

--- a/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml.cs
+++ b/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml.cs
@@ -25,6 +25,12 @@ public partial class TopMenuControl : UserControl
         base.OnAttachedToVisualTree(e);
     }
 
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        _vm.Dispose();
+    }
+
     private string TryGetContainingWindowType()
     {
         return VisualRoot?.GetType().ToString() ?? string.Empty;

--- a/src/TauStellwerk.Desktop/Program.cs
+++ b/src/TauStellwerk.Desktop/Program.cs
@@ -7,6 +7,7 @@ using TauStellwerk.Client.Services;
 using TauStellwerk.Client.Services.Connections;
 using TauStellwerk.Desktop.Services;
 using TauStellwerk.Desktop.Services.WindowSettingService;
+using TauStellwerk.Desktop.ViewModels;
 
 namespace TauStellwerk.Desktop;
 
@@ -26,6 +27,8 @@ public static class Program
         Locator.CurrentMutable.RegisterConstant<IAvaloniaViewService>(avaloniaViewService);
         Locator.CurrentMutable.RegisterConstant(SplatFactory.CreateTurnoutService());
         Locator.CurrentMutable.RegisterConstant<IWindowSettingService>(new WindowSettingService());
+
+        Locator.CurrentMutable.RegisterConstant(new StopButtonControlViewModel());
 
         BuildAvaloniaApp()
             .StartWithClassicDesktopLifetime(args);

--- a/src/TauStellwerk.Desktop/Services/WindowSettingService/IWindowSettingService.cs
+++ b/src/TauStellwerk.Desktop/Services/WindowSettingService/IWindowSettingService.cs
@@ -7,7 +7,11 @@ namespace TauStellwerk.Desktop.Services.WindowSettingService;
 
 public interface IWindowSettingService
 {
+    event EventHandler<(string WindowType, bool UseLargeButton)>? UseLargeButtonChanged;
+
     public void SaveSize(string windowType, Size size);
 
     public Size? LoadSize(string windowType);
+    bool? LoadUseLargeButton(string windowType);
+    void SaveUseLargeButton(string windowType, bool useLargeButton);
 }

--- a/src/TauStellwerk.Desktop/TauStellwerk.Desktop.csproj
+++ b/src/TauStellwerk.Desktop/TauStellwerk.Desktop.csproj
@@ -8,12 +8,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.5" />
+    <PackageReference Include="Avalonia" Version="11.0.6" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.6" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.6" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
     <PackageReference Include="Semi.Avalonia" Version="11.0.1" />
-    <PackageReference Include="Splat" Version="14.8.6" />
+    <PackageReference Include="Splat" Version="14.8.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TauStellwerk.Desktop/ViewModels/Controls/TopMenuViewModel.cs
+++ b/src/TauStellwerk.Desktop/ViewModels/Controls/TopMenuViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of the TauStellwerk project.
 //  Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Splat;
@@ -9,7 +10,7 @@ using TauStellwerk.Desktop.Services.WindowSettingService;
 
 namespace TauStellwerk.Desktop.ViewModels;
 
-public partial class TopMenuViewModel : ViewModelBase
+public partial class TopMenuViewModel : ViewModelBase, IDisposable
 {
     private readonly IAvaloniaViewService _viewService;
     private readonly IWindowSettingService _windowSettingService;
@@ -21,16 +22,20 @@ public partial class TopMenuViewModel : ViewModelBase
 
     public TopMenuViewModel(IAvaloniaViewService? viewService = null)
     {
+        Debug.WriteLine("Creating TopMenuViewModel");
+
         _viewService = viewService ?? Locator.Current.GetService<IAvaloniaViewService>() ?? throw new InvalidOperationException();
         _windowSettingService = Locator.Current.GetService<IWindowSettingService>() ?? throw new InvalidOperationException();
 
-        _windowSettingService.UseLargeButtonChanged += (sender, args) =>
+        _windowSettingService.UseLargeButtonChanged += LargeButtonChangedHandler;
+    }
+
+    private void LargeButtonChangedHandler(object? sender, (string WindowType, bool UseLargeButton) args)
+    {
+        if (args.WindowType == _windowType)
         {
-            if (args.WindowType == _windowType)
-            {
-                UseLargeButton = args.UseLargeButton;
-            }
-        };
+            UseLargeButton = args.UseLargeButton;
+        }
     }
 
     public StopButtonControlViewModel StopButtonVm { get; } = Locator.Current.GetRequiredService<StopButtonControlViewModel>();
@@ -63,5 +68,11 @@ public partial class TopMenuViewModel : ViewModelBase
     protected virtual void OpenTurnoutList()
     {
         _viewService.ShowTurnoutsWindow();
+    }
+
+    public void Dispose()
+    {
+        Debug.WriteLine("Disposing TopMenuViewModel");
+        _windowSettingService.UseLargeButtonChanged -= LargeButtonChangedHandler;
     }
 }

--- a/src/TauStellwerk.Desktop/ViewModels/Controls/TopMenuViewModel.cs
+++ b/src/TauStellwerk.Desktop/ViewModels/Controls/TopMenuViewModel.cs
@@ -33,7 +33,7 @@ public partial class TopMenuViewModel : ViewModelBase
         };
     }
 
-    public StopButtonControlViewModel StopButtonVm { get; } = new();
+    public StopButtonControlViewModel StopButtonVm { get; } = Locator.Current.GetRequiredService<StopButtonControlViewModel>();
 
     public void UpdateWindowType(string windowType)
     {

--- a/src/TauStellwerk.Desktop/ViewModels/Controls/TopMenuViewModel.cs
+++ b/src/TauStellwerk.Desktop/ViewModels/Controls/TopMenuViewModel.cs
@@ -1,22 +1,51 @@
 ﻿// This file is part of the TauStellwerk project.
 //  Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Splat;
 using TauStellwerk.Desktop.Services;
+using TauStellwerk.Desktop.Services.WindowSettingService;
 
 namespace TauStellwerk.Desktop.ViewModels;
 
 public partial class TopMenuViewModel : ViewModelBase
 {
     private readonly IAvaloniaViewService _viewService;
+    private readonly IWindowSettingService _windowSettingService;
+
+    private string _windowType = string.Empty;
+
+    [ObservableProperty]
+    private bool _useLargeButton = false;
 
     public TopMenuViewModel(IAvaloniaViewService? viewService = null)
     {
         _viewService = viewService ?? Locator.Current.GetService<IAvaloniaViewService>() ?? throw new InvalidOperationException();
+        _windowSettingService = Locator.Current.GetService<IWindowSettingService>() ?? throw new InvalidOperationException();
+
+        _windowSettingService.UseLargeButtonChanged += (sender, args) =>
+        {
+            if (args.WindowType == _windowType)
+            {
+                UseLargeButton = args.UseLargeButton;
+            }
+        };
     }
 
     public StopButtonControlViewModel StopButtonVm { get; } = new();
+
+    public void UpdateWindowType(string windowType)
+    {
+        _windowType = windowType;
+        UseLargeButton = _windowSettingService.LoadUseLargeButton(windowType) ?? false;
+    }
+
+    [RelayCommand]
+    protected void ToggleLargeButton()
+    {
+        _windowSettingService.SaveUseLargeButton(_windowType, !UseLargeButton);
+    }
 
     [RelayCommand]
     protected virtual void OpenEngineList()

--- a/src/TauStellwerk.Desktop/Views/Engine/EngineSelectionWindow.axaml
+++ b/src/TauStellwerk.Desktop/Views/Engine/EngineSelectionWindow.axaml
@@ -16,12 +16,10 @@
 	<Design.DataContext>
 		<viewModels:EngineSelectionViewModel/>
 	</Design.DataContext>
-	<Panel Margin="0 5 0 5">
+	<DockPanel>
+        <controls:TopMenuControl DockPanel.Dock="Top"/>
 		<DockPanel LastChildFill="False">
-			<StackPanel Orientation="Vertical" DockPanel.Dock="Top" Margin="5">
-				<controls:TopMenuControl/>
-				<Separator/>
-				<StackPanel Orientation="Horizontal">
+				<StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
 					<TextBox AcceptsReturn="False" AcceptsTab="False" MaxLines="1" Watermark="{x:Static r:Resources.Search}" Width="200" Text="{Binding CurrentSearchTerm}"/>
 					<ComboBox ItemsSource="{Binding EngineSortModes}"
 					          SelectedItem="{Binding CurrentEngineSortMode}"/>
@@ -29,7 +27,6 @@
 					          SelectedItem="{Binding CurrentEngineSortDirection}"/>
 					<CheckBox IsChecked="{Binding ShowHiddenEngines}" Margin="5, 0 , 5,0" Content="{x:Static r:Resources.ShowHidden}"/>
 				</StackPanel>
-			</StackPanel>
 			<DockPanel DockPanel.Dock="Bottom" LastChildFill="False" Margin="5">
 				<Button Command="{CompiledBinding ScrollPages}"
                         DockPanel.Dock="Left"
@@ -98,5 +95,5 @@
 				</ItemsControl>
 			</ScrollViewer>
 		</DockPanel>
-	</Panel>
+	</DockPanel>
 </Window>

--- a/src/TauStellwerk.Desktop/Views/SettingsWindow.axaml
+++ b/src/TauStellwerk.Desktop/Views/SettingsWindow.axaml
@@ -14,35 +14,37 @@
         <viewModels:SettingsViewModel />
     </Design.DataContext>
     <Window.Styles>
-        <Style Selector="StackPanel">
+        <Style Selector="StackPanel > StackPanel, DockPanel > StackPanel">
             <Setter Property="Margin" Value="2 4" />
         </Style>
     </Window.Styles>
-    <StackPanel>
-        <controls:TopMenuControl/>
-        <StackPanel ToolTip.Tip="{x:Static r:Resources.UsernameSettingDescription}" Margin="2">
-            <Label Content="{x:Static r:Resources.Username}" />
-            <TextBox Text="{Binding Settings.Username, Mode=TwoWay, FallbackValue={}}" />
-        </StackPanel>
-        <StackPanel ToolTip.Tip="{x:Static r:Resources.ServerAddressSettingDescription}" Margin="2">
-            <Label Content="{x:Static r:Resources.ServerAddress}" />
-            <TextBox Text="{Binding Settings.ServerAddress, Mode=TwoWay, FallbackValue={}}" />
-        </StackPanel>
+    <DockPanel>
+        <controls:TopMenuControl DockPanel.Dock="Top"/>
         <StackPanel>
-            <Label>Theme</Label>
-            <ComboBox SelectedItem="{Binding Settings.Theme, FallbackValue={}}" ItemsSource="{Binding AvailableThemes}">
-            </ComboBox>
+            <StackPanel ToolTip.Tip="{x:Static r:Resources.UsernameSettingDescription}" Margin="2">
+                <Label Content="{x:Static r:Resources.Username}" />
+                <TextBox Text="{Binding Settings.Username, Mode=TwoWay, FallbackValue={}}" />
+            </StackPanel>
+            <StackPanel ToolTip.Tip="{x:Static r:Resources.ServerAddressSettingDescription}" Margin="2">
+                <Label Content="{x:Static r:Resources.ServerAddress}" />
+                <TextBox Text="{Binding Settings.ServerAddress, Mode=TwoWay, FallbackValue={}}" />
+            </StackPanel>
+            <StackPanel>
+                <Label>Theme</Label>
+                <ComboBox SelectedItem="{Binding Settings.Theme, FallbackValue={}}" ItemsSource="{Binding AvailableThemes}">
+                </ComboBox>
+            </StackPanel>
+            <StackPanel ToolTip.Tip="{x:Static r:Resources.LanguageSettingDescription}">
+                <Label Content="{x:Static r:Resources.Language}"/>
+                <ComboBox SelectedItem="{Binding Settings.Language}" ItemsSource="{Binding AvailableLanguages}"/>
+            </StackPanel>
+            <StackPanel>
+                <TextBlock Text="{Binding ApplicationInformation}"/>
+            </StackPanel>
+            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="2">
+                <Button Command="{Binding CancelCommand}" Content="{x:Static r:Resources.Cancel}" MinWidth="100" HorizontalContentAlignment="Center" Theme="{DynamicResource SolidButton}"/>
+                <Button Command="{Binding SaveCommand}" Content="{x:Static r:Resources.Save}" MinWidth="100" HorizontalContentAlignment="Center" Theme="{DynamicResource SolidButton}"/>
+            </StackPanel>
         </StackPanel>
-		<StackPanel ToolTip.Tip="{x:Static r:Resources.LanguageSettingDescription}">
-            <Label Content="{x:Static r:Resources.Language}"/>
-            <ComboBox SelectedItem="{Binding Settings.Language}" ItemsSource="{Binding AvailableLanguages}"/>
-        </StackPanel>
-        <StackPanel>
-            	<TextBlock Text="{Binding ApplicationInformation}"/>
-        </StackPanel>
-        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="2">
-            <Button Command="{Binding CancelCommand}" Content="{x:Static r:Resources.Cancel}" MinWidth="100" HorizontalContentAlignment="Center" Theme="{DynamicResource SolidButton}"/>
-            <Button Command="{Binding SaveCommand}" Content="{x:Static r:Resources.Save}" MinWidth="100" HorizontalContentAlignment="Center" Theme="{DynamicResource SolidButton}"/>
-        </StackPanel>
-    </StackPanel>
+    </DockPanel>
 </Window>

--- a/src/TauStellwerk.WebClient/App.razor
+++ b/src/TauStellwerk.WebClient/App.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData"/>
     </Found>

--- a/test/TauStellwerk.Base.Tests/TauStellwerk.Base.Tests.csproj
+++ b/test/TauStellwerk.Base.Tests/TauStellwerk.Base.Tests.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/TauStellwerk.Client.Tests/TauStellwerk.Client.Tests.csproj
+++ b/test/TauStellwerk.Client.Tests/TauStellwerk.Client.Tests.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/TauStellwerk.CommandStations.Tests/TauStellwerk.CommandStations.Tests.csproj
+++ b/test/TauStellwerk.CommandStations.Tests/TauStellwerk.CommandStations.Tests.csproj
@@ -9,9 +9,9 @@
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.9.0">
+		<PackageReference Include="NUnit.Analyzers" Version="3.10.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/test/TauStellwerk.Data.Tests/TauStellwerk.Data.Tests.csproj
+++ b/test/TauStellwerk.Data.Tests/TauStellwerk.Data.Tests.csproj
@@ -8,9 +8,9 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit" Version="4.0.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.9.0">
+		<PackageReference Include="NUnit.Analyzers" Version="3.10.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/test/TauStellwerk.Server.IntegrationTests/TauStellwerk.Server.IntegrationTests.csproj
+++ b/test/TauStellwerk.Server.IntegrationTests/TauStellwerk.Server.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/test/TauStellwerk.Server.Test/TauStellwerk.Server.Test.csproj
+++ b/test/TauStellwerk.Server.Test/TauStellwerk.Server.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <DocumentationFile>.\bin\TauStellwerk.Test.xml</DocumentationFile>
@@ -24,7 +24,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.1" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>

--- a/test/TauStellwerk.Util.Tests/CounterDictionaryTests.cs
+++ b/test/TauStellwerk.Util.Tests/CounterDictionaryTests.cs
@@ -2,6 +2,7 @@
 //  Licensed under the GNU GPL license. See LICENSE file in the project root for full license information.
 
 
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace TauStellwerk.Util.Tests;
@@ -18,20 +19,22 @@ public class CounterDictionaryTests
     [TestCase(new[] { 1, 2 }, 1.5d)]
     [TestCase(new[] { 1, 2, 1, 2 }, 1.5d)]
     [TestCase(new[] { 1, 1, 1, 3 }, 1.5d)]
-    public void AverageCaseTest(int[] values, double? result)
+    public void AverageCaseTest(int[] values, double? expectedResult)
     {
         var ct = CounterFromArray(values);
-        Assert.AreEqual(result, ct.Average());
+        var result = ct.Average();
+        result.Should().Be(expectedResult);
     }
 
     [TestCase(new int[] { }, 0)]
     [TestCase(new[] { 0 }, 1)]
     [TestCase(new[] { 2 }, 1)]
     [TestCase(new[] { 2, 2, 1, 3, 1929 }, 5)]
-    public void CountTest(int[] values, long result)
+    public void CountTest(int[] values, long expectedResult)
     {
         var ct = CounterFromArray(values);
-        Assert.AreEqual(result, ct.Count());
+        var result = ct.Count();
+        result.Should().Be(expectedResult);
     }
 
     [Test]
@@ -43,16 +46,18 @@ public class CounterDictionaryTests
             ct.Increment(i);
         }
 
-        Assert.AreEqual(90_000, ct.Get90ThPercentile());
-        Assert.AreEqual(95_000, ct.Get95ThPercentile());
-        Assert.AreEqual(99_000, ct.Get99ThPercentile());
+        ct.Get90ThPercentile().Should().Be(90_000);
+        ct.Get95ThPercentile().Should().Be(95_000);
+        ct.Get99ThPercentile().Should().Be(99_000);
     }
 
     [Test]
     public void PercentilesOnEmptyNull()
     {
         var ct = new CounterDictionary();
-        Assert.IsNull(ct.Get90ThPercentile());
+        ct.Get90ThPercentile().Should().BeNull();
+        ct.Get95ThPercentile().Should().BeNull();
+        ct.Get99ThPercentile().Should().BeNull();
     }
 
     [Test]
@@ -67,7 +72,7 @@ public class CounterDictionaryTests
 
         ct.Combine(ct2);
 
-        Assert.AreEqual(5, ct.GetByKey(3));
+        ct.GetByKey(3).Should().Be(5);
     }
 
     private static CounterDictionary SimpleTestCounterDictionary()

--- a/test/TauStellwerk.Util.Tests/MultiDictionaryTests.cs
+++ b/test/TauStellwerk.Util.Tests/MultiDictionaryTests.cs
@@ -34,12 +34,12 @@ public class MultiDictionaryTests
         mdict.Add(2, "Zwo");
 
         mdict.TryRemoveFirst(2, out var out1);
-        Assert.AreEqual("Deux", out1);
+        out1.Should().Be("Deux");
 
         mdict.TryRemoveFirst(2, out var out2);
-        Assert.AreEqual("Zwo", out2);
+        out2.Should().Be("Zwo");
 
-        Assert.False(mdict.TryRemoveFirst(2, out _));
+        mdict.TryRemoveFirst(2, out _).Should().BeFalse();
     }
 
     /// <summary>
@@ -60,10 +60,10 @@ public class MultiDictionaryTests
 
         var list = immutableList!.ToList();
 
-        Assert.AreEqual(3, list.Count);
-        Assert.Contains("Eins", list);
-        Assert.Contains("One", list);
-        Assert.Contains("Uno", list);
+        list.Count.Should().Be(3);
+        list.Should().Contain("Eins");
+        list.Should().Contain("One");
+        list.Should().Contain("Uno");
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ public class MultiDictionaryTests
         var mdict = new MultiDictionary<int, object>();
         var success = mdict.TryGetAllValues(482001, out var list);
 
-        Assert.False(success);
-        Assert.IsNull(list);
+        success.Should().BeFalse();
+        list.Should().BeNull();
     }
 }

--- a/test/TauStellwerk.Util.Tests/TauStellwerk.Util.Tests.csproj
+++ b/test/TauStellwerk.Util.Tests/TauStellwerk.Util.Tests.csproj
@@ -12,7 +12,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>


### PR DESCRIPTION
- Users can selected the "old large button" instead of the small menu entry
- Only a single settings window can be opened at any one time
- styling improvments

- Update dependencies, including the Migration from NUnit 3 to 4, replacing left over legacy assertions with the FluentAssertions