### PR TITLE
Publish framework dependent Builds rather than self-contained one

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Currently supported Command Stations:
 - ESU Command Station (ECoS)
 - DCC++ EX (via USB)
 
+## Requirements
+TauStellwerk requires the ASP.NET Core Runtime 8.0 to be installed.
+See the [Microsoft .NET Download page](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) for downloads and installation instructions.
 
 ### MacOS/iOS
 

--- a/publish.py
+++ b/publish.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from glob import glob
 
-customargs="-c Release --self-contained /p:DebugSymbols=false /p:DebugType=None  /p:EnableCompressionInSingleFile=true /p:PublishTrimmed=true /p:TrimMode=partial /p:TreatWarningsAsErrors=false /nowarn:IL2026,IL2111,IL2104,IL2110,IL2091"
+customargs="-c Release /p:DebugSymbols=false /p:DebugType=None"
 rids = ["linux-x64","linux-musl-x64","linux-arm64","linux-musl-arm64","win-x64","win-arm64"]
 
 BLUE='\033[1;34m'

--- a/src/TauStellwerk.Server/TauStellwerk.Server.csproj
+++ b/src/TauStellwerk.Server/TauStellwerk.Server.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PublishSingleFile>true</PublishSingleFile>
-    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
self-contained builds were a workaround because of the annoying installation of .NET on arm64 Debian - there is at least one unofficial package feed now, so the installation isn't nearly as painful anymore.

With framework dependent builds, patches for the Runtime no longer require rebuilds of TauStellwerk.