### PR TITLE
Ensure small stop button is disabled during the "lockout" period

### DIFF
--- a/src/TauStellwerk.Client/Resources/Resources.Designer.cs
+++ b/src/TauStellwerk.Client/Resources/Resources.Designer.cs
@@ -375,7 +375,7 @@ namespace TauStellwerk.Client.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TauStellwerk was stopped by:.
+        ///   Looks up a localized string similar to Stopped by:.
         /// </summary>
         public static string StatusStoppedSubtitle {
             get {

--- a/src/TauStellwerk.Client/Resources/Resources.de.resx
+++ b/src/TauStellwerk.Client/Resources/Resources.de.resx
@@ -211,7 +211,7 @@
     <value>STOP</value>
   </data>
   <data name="StatusStoppedSubtitle" xml:space="preserve">
-    <value>TauStellwerk wurde gestopt von:</value>
+    <value>Gestopt von:</value>
   </data>
   <data name="StatusRunning" xml:space="preserve">
     <value>AKTIV</value>

--- a/src/TauStellwerk.Client/Resources/Resources.gsw.resx
+++ b/src/TauStellwerk.Client/Resources/Resources.gsw.resx
@@ -111,9 +111,9 @@
     <data name="StatusStopped" xml:space="preserve">
         <value>STOP</value>
     </data>
-    <data name="StatusStoppedSubtitle" xml:space="preserve">
-        <value>TauStellwerk isch gschtopt worde vo:</value>
-    </data>
+  <data name="StatusStoppedSubtitle" xml:space="preserve">
+    <value>Gschtopt worde vo:</value>
+  </data>
     <data name="StatusRunning" xml:space="preserve">
         <value>AKTIV</value>
     </data>
@@ -149,5 +149,8 @@
   </data>
   <data name="NonePlaceholder" xml:space="preserve">
     <value>Keini</value>
+  </data>
+  <data name="Write" xml:space="preserve">
+    <value>Schribe</value>
   </data>
 </root>

--- a/src/TauStellwerk.Client/Resources/Resources.resx
+++ b/src/TauStellwerk.Client/Resources/Resources.resx
@@ -211,7 +211,7 @@
     <value>STOPPED</value>
   </data>
   <data name="StatusStoppedSubtitle" xml:space="preserve">
-    <value>TauStellwerk was stopped by:</value>
+    <value>Stopped by:</value>
   </data>
   <data name="StatusStoppedLocked" xml:space="preserve">
     <value>STOPPED (LOCKED)</value>

--- a/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml
+++ b/src/TauStellwerk.Desktop/Controls/TopMenuControl.axaml
@@ -40,6 +40,7 @@
                     Command="{Binding StopButtonVm.StopButtonCommand}"
                     Header="{Binding StopButtonVm.CurrentState}"
                     Tag="{Binding StopButtonVm.ButtonClass}"
+                    IsEnabled="{Binding StopButtonVm.ShouldBeEnabled}"
                 >
                     <ToolTip.Tip>
                         <TextBlock>


### PR DESCRIPTION
Fixes #359 
Also shortens the description of the stop button a bit to better fit in slim windows and fixes a missing gsw string. 